### PR TITLE
fix vgcreate to include all drives

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,8 @@ then
         done
 
 
-        echo "Creating VG=instancestore $disks"
-        vgcreate instancestore $disks
+        echo "Creating VG=instancestore $(printf '%s ' ${disks[@]})"
+        vgcreate instancestore $(printf '%s ' ${disks[@]})
     fi
 else
     echo "VG exists"


### PR DESCRIPTION
Currently only the first drive from the list is included into volume group. My change is to print the disks values as a string.

**current:**
```
echo $disks
/dev/nvme7n1
```

**fix:**
```
echo $(printf '%s ' ${disks[@]})
/dev/nvme7n1 /dev/nvme6n1 /dev/nvme5n1 /dev/nvme4n1 /dev/nvme3n1 /dev/nvme2n1 /dev/nvme1n1 /dev/nvme0n1
```